### PR TITLE
Set hostname before starting wifi to properly identify to DHCP server

### DIFF
--- a/ESP-Serial-Bridge.ino
+++ b/ESP-Serial-Bridge.ino
@@ -141,6 +141,7 @@ void WiFiStationDisconnected(WiFiEvent_t event, WiFiEventInfo_t info) {
 
 #ifdef MODE_STA
         debug.println("Open ESP Station Mode");
+        WiFi.setHostname(HOSTNAME);
         WiFi.mode(WIFI_STA);
 #ifdef ESP32
         WiFi.onEvent(WiFiStationDisconnected,


### PR DESCRIPTION
At least for ESP32, the hostname needs to be set before setting WiFi mode (even before WiFi.begin like usually mentioned) to avoid hostname to get overridden to ESP-XXXX